### PR TITLE
fix(ci): switch from codegen to verifying that clients are uptodate

### DIFF
--- a/.github/workflows/generate-client.yml
+++ b/.github/workflows/generate-client.yml
@@ -1,61 +1,51 @@
-name: Generate Client
+name: Verify Generated Client
 
 on:
   pull_request:
-    types:
-    - opened
-    - synchronize
 
 jobs:
-  generate-client:
-    permissions:
-      contents: write
+  verify-client:
     runs-on: ubuntu-latest
     steps:
-    # For PRs from forks
-    - uses: actions/checkout@v5
-    # For PRs from the same repo
-    - uses: actions/checkout@v5
-      if: ( github.event_name != 'pull_request' || github.secret_source == 'Actions' )
-      with:
-        ref: ${{ github.head_ref }}
-        token: ${{ secrets.FULL_STACK_FASTAPI_TEMPLATE_REPO_TOKEN }}
-    - uses: actions/setup-node@v6
-      with:
-        node-version: lts/*
-    - uses: actions/setup-python@v6
-      with:
-        python-version: "3.10"
-    - name: Install uv
-      uses: astral-sh/setup-uv@v7
-      with:
-        version: "0.4.15"
-        enable-cache: true
-    - name: Install dependencies
-      run: npm ci
-      working-directory: frontend/admin
-    - run: uv sync
-      working-directory: backend
-    - run: uv run bash scripts/generate-client.sh
-      env:
-        VIRTUAL_ENV: backend/.venv
-        SECRET_KEY: just-for-generating-client
-        POSTGRES_PASSWORD: just-for-generating-client
-        FIRST_SUPERUSER_PASSWORD: just-for-generating-client
-    - name: Add admin changes to git
-      run: |
-        git config --local user.email "github-actions@github.com"
-        git config --local user.name "github-actions"
-        git add frontend/admin/src/client
-        git add frontend/student/src/client 
-    # Same repo PRs
-    - name: Push changes
-      if: ( github.event_name != 'pull_request' || github.secret_source == 'Actions' )
-      run: |
-        git diff --staged --quiet || git commit -m "✨ Autogenerate frontend client"
-        git push
-    # Fork PRs
-    - name: Check changes
-      if: ( github.event_name == 'pull_request' && github.secret_source != 'Actions' )
-      run: |
-        git diff --staged --quiet || (echo "Changes detected in generated client, run scripts/generate-client.sh and commit the changes" && exit 1)
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.4.15"
+          enable-cache: true
+
+      - name: Install admin frontend dependencies
+        run: npm ci
+        working-directory: frontend/admin
+
+      - name: Install backend dependencies
+        run: uv sync
+        working-directory: backend
+
+      - name: Generate client
+        run: uv run bash scripts/generate-client.sh
+        env:
+          VIRTUAL_ENV: backend/.venv
+          SECRET_KEY: just-for-generating-client
+          POSTGRES_PASSWORD: just-for-generating-client
+          FIRST_SUPERUSER_PASSWORD: just-for-generating-client
+
+      # This only checks for frontend/admin client changes.
+      # Similar steps should be added when the script generates other clients.
+      - name: Check for uncommitted changes
+        run: |
+          if ! git diff --quiet frontend/admin/src/client; then
+            echo "::error::Generated client is out of date. Run 'bash scripts/generate-client.sh' locally and commit the changes."
+            git diff --stat frontend/admin/src/client
+            exit 1
+          fi
+          echo "✅ Generated client is up to date."


### PR DESCRIPTION
Old workflow was generating clients and pushing code. It was failing due to missing tokens to push code.

I think a better approach is to verify clients are up-to-date instead. The new workflow just makes sure the clients don't need to be generated, but clients should be the dev's responsibility.