### PR TITLE
Remove tracked env files and replace with .env.example template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Copy this file to .env and fill in your local values:
+#   cp .env.example .env
+
 # Domain
 # This would be set to the production domain with an env var on deployment
 # used by Traefik to transmit traffic and aqcuire TLS certificates

--- a/.github/workflows/generate-client.yml
+++ b/.github/workflows/generate-client.yml
@@ -35,6 +35,9 @@ jobs:
         run: uv sync
         working-directory: backend
 
+      - name: Create .env from template
+        run: cp .env.example .env
+
       - name: Generate client
         run: uv run bash scripts/generate-client.sh
         env:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,7 +31,7 @@ jobs:
           changed:
             - backend/**
             - frontend/**
-            - .env
+            - .env.example
             - docker-compose*.yml
             - .github/workflows/playwright.yml
 
@@ -48,6 +48,8 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v6
+    - name: Create .env from template
+      run: cp .env.example .env
     - uses: actions/setup-node@v6
       with:
         node-version: lts/*

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           version: "0.4.15"
           enable-cache: true
+      - name: Create .env from template
+        run: cp .env.example .env
       - run: docker compose down -v --remove-orphans
       - run: docker compose up -d db mailcatcher
       - name: Migrate DB

--- a/.github/workflows/test-docker-compose.yml
+++ b/.github/workflows/test-docker-compose.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Create .env from template
+        run: cp .env.example .env
       - run: docker compose build
       - run: docker compose down -v --remove-orphans
       - run: docker compose up -d --wait backend frontend-admin frontend-student adminer

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.env
 node_modules/
 /test-results/
 /playwright-report/

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@
 
 ### Configure
 
+The `.env` files are not tracked in Git. Create them from the provided templates before running the stack:
+
+```bash
+cp .env.example .env
+cp frontend/admin/.env.example frontend/admin/.env
+cp frontend/student/.env.example frontend/student/.env
+```
+
 You can update configs in the `.env` files to customize your configurations.
 
 Before deploying it, make sure you change at least the values for:

--- a/development.md
+++ b/development.md
@@ -116,6 +116,14 @@ docker compose watch
 
 The `.env` file is the one that contains all your configurations, generated keys and passwords, etc.
 
+It is not tracked in Git. Create it (and the per-frontend ones) from the provided templates before running the stack:
+
+```bash
+cp .env.example .env
+cp frontend/admin/.env.example frontend/admin/.env
+cp frontend/student/.env.example frontend/student/.env
+```
+
 Depending on your workflow, you could want to exclude it from Git, for example if your project is public. In that case, you would have to make sure to set up a way for your CI tools to obtain it while building or deploying your project.
 
 One way to do it could be to add each environment variable to your CI/CD system, and updating the `docker-compose.yml` file to read that specific env var instead of reading the `.env` file.

--- a/frontend/admin/.env
+++ b/frontend/admin/.env
@@ -1,2 +1,0 @@
-VITE_API_URL=http://localhost:8000
-MAILCATCHER_HOST=http://localhost:1080

--- a/frontend/admin/.env.example
+++ b/frontend/admin/.env.example
@@ -1,0 +1,5 @@
+# Copy this file to .env and adjust for your local setup:
+#   cp .env.example .env
+
+VITE_API_URL=http://localhost:8000
+MAILCATCHER_HOST=http://localhost:1080

--- a/frontend/admin/.gitignore
+++ b/frontend/admin/.gitignore
@@ -31,6 +31,7 @@ openapi.json
 
 .env
 .env.*
+!.env.example
 *.md
 *.test.ts
 *.spec.ts

--- a/frontend/student/.env
+++ b/frontend/student/.env
@@ -1,4 +1,0 @@
-# VITE_API_URL=http://localhost:8000
-MAILCATCHER_HOST=http://localhost:1080
-
-VITE_API_URL=https://api.staging.stacklabs.cc

--- a/frontend/student/.env.example
+++ b/frontend/student/.env.example
@@ -1,0 +1,5 @@
+# Copy this file to .env and adjust for your local setup:
+#   cp .env.example .env
+
+VITE_API_URL=http://localhost:8000
+MAILCATCHER_HOST=http://localhost:1080

--- a/frontend/student/.gitignore
+++ b/frontend/student/.gitignore
@@ -28,3 +28,10 @@ openapi.json
 /blob-report/
 /playwright/.cache/
 /playwright/.auth/
+
+.env
+.env.*
+!.env.example
+*.md
+*.test.ts
+*.spec.ts


### PR DESCRIPTION
## Changes

- Removed tracked `.env` files from frontend applications.
- Renamed environment templates to `.env.example`.
- Added `.env` files to `.gitignore`.

## Purpose
Prevent environment-specific files from being committed while providing .env.example templates for local setup.