### PR TITLE
Update Dependabot  configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,8 +28,9 @@ updates:
   # Docker
   - package-ecosystem: docker
     directories:
-      - /backend
-      - /frontend
+      - "/backend"
+      - "/frontend/admin"
+      - "/frontend/student"
     schedule:
       interval: weekly
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,9 @@ updates:
       prefix: "chore(backend):"
   # npm
   - package-ecosystem: npm
-    directory: /frontend
+    directories:
+      - "/frontend/admin"
+      - "/frontend/student"
     schedule:
       interval: weekly
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,12 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
     commit-message:
       prefix: "chore(ci):"
+    groups:
+      github-actions:
+        patterns: ["*"]
   # Python uv
   - package-ecosystem: uv
     directory: /backend
@@ -14,6 +17,9 @@ updates:
       interval: weekly
     commit-message:
       prefix: "chore(backend):"
+    groups:
+      backend-minor-patch:
+        update-types: ["minor", "patch"]
   # npm
   - package-ecosystem: npm
     directories:
@@ -25,6 +31,9 @@ updates:
       prefix: "chore(frontend):"
     ignore:
       - dependency-name: "@hey-api/openapi-ts"
+    groups:
+      frontend-minor-patch:
+        update-types: ["minor", "patch"]
   # Docker
   - package-ecosystem: docker
     directories:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,8 @@ updates:
     commit-message:
       prefix: "chore(frontend):"
     ignore:
+      # Pinned: upgrading regenerates the API client and breaks the
+      # verify-client check until the client is regenerated and committed.
       - dependency-name: "@hey-api/openapi-ts"
     groups:
       frontend-minor-patch:


### PR DESCRIPTION
- **Fix npm directory** — pointed the npm ecosystem at `/frontend/admin` and
  `/frontend/student` instead of `/frontend`, which has no `package.json`.
- **Fix docker directories** — pointed the docker ecosystem at `/backend`,
  `/frontend/admin`, and `/frontend/student` (the frontend Dockerfiles live in
  the app subdirectories, not `/frontend`).
- **Group updates** — grouped github-actions, backend (uv), and frontend (npm)
  minor/patch bumps to cut PR noise, and aligned the github-actions schedule to
  `weekly` for consistency.
- **Document the `@hey-api/openapi-ts` ignore** — added a comment explaining the
  pin (upgrading regenerates the API client and breaks `verify-client` until the
  client is regenerated and committed).