### PR TITLE
Update Dependabot  groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,8 +34,11 @@ updates:
       # verify-client check until the client is regenerated and committed.
       - dependency-name: "@hey-api/openapi-ts"
     groups:
+      playwright:
+        patterns: ["@playwright/test"]
       frontend-minor-patch:
         update-types: ["minor", "patch"]
+        exclude-patterns: ["@playwright/test"]
   # Docker
   - package-ecosystem: docker
     directories:
@@ -46,6 +49,9 @@ updates:
       interval: weekly
     commit-message:
       prefix: "chore(tools/docker):"
+    groups:
+      playwright:
+        patterns: ["mcr.microsoft.com/playwright"]
   # Docker Compose
   - package-ecosystem: docker-compose
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,11 +20,26 @@ updates:
     groups:
       backend-minor-patch:
         update-types: ["minor", "patch"]
-  # npm
+  # npm admin app
   - package-ecosystem: npm
-    directories:
-      - "/frontend/admin"
-      - "/frontend/student"
+    directory: "/frontend/admin"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(frontend):"
+    ignore:
+      # Pinned: upgrading regenerates the API client and breaks the
+      # verify-client check until the client is regenerated and committed.
+      - dependency-name: "@hey-api/openapi-ts"
+    groups:
+      playwright:
+        patterns: ["@playwright/test"]
+      frontend-minor-patch:
+        update-types: ["minor", "patch"]
+        exclude-patterns: ["@playwright/test"]
+  # npm student app
+  - package-ecosystem: npm
+    directory: "/frontend/student"
     schedule:
       interval: weekly
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,7 @@ updates:
     schedule:
       interval: weekly
     commit-message:
-      prefix: "chore(frontend):"
+      prefix: "chore(frontend/admin):"
     ignore:
       # Pinned: upgrading regenerates the API client and breaks the
       # verify-client check until the client is regenerated and committed.
@@ -43,7 +43,7 @@ updates:
     schedule:
       interval: weekly
     commit-message:
-      prefix: "chore(frontend):"
+      prefix: "chore(frontend/student):"
     ignore:
       # Pinned: upgrading regenerates the API client and breaks the
       # verify-client check until the client is regenerated and committed.


### PR DESCRIPTION
- Split the single npm Dependabot block (which covered both frontends via directories) into separate blocks for frontend/admin and frontend/student, so each produces independent PRs
- Added a playwright group to both npm blocks, isolating @playwright/test bumps from the catch-all frontend-minor-patch group
- Added a playwright group to the Docker block, isolating mcr.microsoft.com/playwright image bumps

Playwright's npm package and Docker image must stay at the same version. Grouping them separately in each ecosystem makes the paired updates easy to identify and review together, preventing silent version drift.