### PR TITLE
chore(frontend/admin): migrate biome config to 2.5.x

### DIFF
--- a/frontend/admin/biome.json
+++ b/frontend/admin/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "files": {
     "includes": [
@@ -10,13 +10,14 @@
       "!**/src/client/**/*",
       "!**/src/components/ui/**/*",
       "!**/playwright-report",
-      "!**/playwright.config.ts"
+      "!**/playwright.config.ts",
+      "!**/*.svg"
     ]
   },
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "suspicious": {
         "noExplicitAny": "off",
         "noArrayIndexKey": "off"


### PR DESCRIPTION
Fixes the failing `lint-frontend (frontend/admin)` check on #158.

The group bumps `@biomejs/biome` 2.3.11 → 2.5.2, which:
- removes the `linter.rules.recommended` field (now `preset: "recommended"`)
- expects the `$schema` to match 2.5.2
- started linting raw `.svg` asset files (`noSvgWithoutTitle` on the vendored logo)

This runs `biome migrate` and excludes `**/*.svg` static assets from linting so
`biome ci` passes. Targets the Dependabot branch so #158 is not abandoned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
